### PR TITLE
Resolve unresolved references

### DIFF
--- a/EdFi.Tools.ApiPublisher.Cli/EdFi.Tools.ApiPublisher.Cli.csproj
+++ b/EdFi.Tools.ApiPublisher.Cli/EdFi.Tools.ApiPublisher.Cli.csproj
@@ -7,8 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="AWS.Logger.Log4net" Version="3.2.1" />
       <PackageReference Include="Castle.Windsor" Version="5.0.1" />
-      <PackageReference Include="log4net" Version="2.0.8" />
+      <PackageReference Include="log4net" Version="2.0.12" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.4" />
       <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.0.2" />
       <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.0.2" />

--- a/EdFi.Tools.ApiPublisher.Core/EdFi.Tools.ApiPublisher.Core.csproj
+++ b/EdFi.Tools.ApiPublisher.Core/EdFi.Tools.ApiPublisher.Core.csproj
@@ -6,7 +6,7 @@
 
     <ItemGroup>
       <PackageReference Include="Castle.Windsor" Version="5.0.1" />
-      <PackageReference Include="log4net" Version="2.0.8" />
+      <PackageReference Include="log4net" Version="2.0.12" />
       <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.4" />
       <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.0.2" />

--- a/EdFi.Tools.ApiPublisher.Core/Extensions/StringExtensions.cs
+++ b/EdFi.Tools.ApiPublisher.Core/Extensions/StringExtensions.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 namespace EdFi.Tools.ApiPublisher.Core.Extensions
 {
     public static class StringExtensions
@@ -53,5 +55,47 @@ namespace EdFi.Tools.ApiPublisher.Core.Extensions
 
             return text;
         }
-    }
+        
+        /// <summary>
+        /// Returns a string that is converted to camel casing, detecting and handling acronyms as prefixes and suffixes.
+        /// </summary>
+        /// <param name="text">The text to be processed.</param>
+        /// <returns>A string that has the first character converted to lower-case.</returns>
+        public static string ToCamelCase(this string text)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return text;
+            }
+
+            if (text.Length == 1)
+            {
+                return text.ToLower();
+            }
+
+            int leadingUpperCharsLength = text.TakeWhile(char.IsUpper).Count();
+
+            int prefixLength = leadingUpperCharsLength - 1;
+
+            if (text.Length == leadingUpperCharsLength
+
+                // Handles the case of an acronym with a trailing "s" (e.g. "URIs" -> "uris" not "urIs")
+                || text.Length == leadingUpperCharsLength + 1 && text.EndsWith("s"))
+            {
+                // Convert entire name to lower case
+                return text.ToLower();
+            }
+
+            if (prefixLength > 0)
+            {
+                // Apply lower casing to leading acronym
+                return text.Substring(0, prefixLength)
+                        .ToLower()
+                    + text.Substring(prefixLength);
+            }
+
+            // Apply simple camel casing
+            return char.ToLower(text[0]) + text.Substring(1);
+        }
+}
 }

--- a/EdFi.Tools.ApiPublisher.Core/Processing/Blocks/ChangeResourceKey.cs
+++ b/EdFi.Tools.ApiPublisher.Core/Processing/Blocks/ChangeResourceKey.cs
@@ -21,21 +21,22 @@ namespace EdFi.Tools.ApiPublisher.Core.Processing.Blocks
     public static class ChangeResourceKey
     {
         private static readonly ILog _logger = LogManager.GetLogger(typeof(ChangeResourceKey));
-        
+
         public static ValueTuple<ITargetBlock<GetItemForKeyChangeMessage>, ISourceBlock<ErrorItemMessage>> CreateBlocks(
-            EdFiApiClient targetApiClient, Options options,
-            ITargetBlock<ErrorItemMessage> errorHandlingBlock)
-         {
-            var getItemForKeyChangeBlock =
-                CreateGetItemForKeyChangeBlock(targetApiClient, options, errorHandlingBlock);
-            
-            var changeKeyResourceBlock = CreateChangeKeyBlock(targetApiClient, options);
-            
-            getItemForKeyChangeBlock.LinkTo(changeKeyResourceBlock, new DataflowLinkOptions {PropagateCompletion = true});
-            
+            CreateBlocksRequest createBlocksRequest)
+        {
+            var getItemForKeyChangeBlock = CreateGetItemForKeyChangeBlock(
+                createBlocksRequest.TargetApiClient,
+                createBlocksRequest.Options,
+                createBlocksRequest.ErrorHandlingBlock);
+
+            var changeKeyResourceBlock = CreateChangeKeyBlock(createBlocksRequest.TargetApiClient, createBlocksRequest.Options);
+
+            getItemForKeyChangeBlock.LinkTo(changeKeyResourceBlock, new DataflowLinkOptions { PropagateCompletion = true });
+
             return (getItemForKeyChangeBlock, changeKeyResourceBlock);
-         }
-        
+        }
+
         private static TransformManyBlock<GetItemForKeyChangeMessage, ChangeKeyMessage> CreateGetItemForKeyChangeBlock(
             EdFiApiClient targetApiClient, 
             Options options, 

--- a/EdFi.Tools.ApiPublisher.Core/Processing/Blocks/CreateBlocksRequest.cs
+++ b/EdFi.Tools.ApiPublisher.Core/Processing/Blocks/CreateBlocksRequest.cs
@@ -1,0 +1,25 @@
+using System.Threading.Tasks.Dataflow;
+using EdFi.Tools.ApiPublisher.Core.ApiClientManagement;
+using EdFi.Tools.ApiPublisher.Core.Configuration;
+using EdFi.Tools.ApiPublisher.Core.Processing.Messages;
+
+namespace EdFi.Tools.ApiPublisher.Core.Processing.Blocks
+{
+    public class CreateBlocksRequest
+    {
+        public CreateBlocksRequest(EdFiApiClient sourceApiClient, EdFiApiClient targetApiClient, Options options, AuthorizationFailureHandling[] authorizationFailureHandling, ITargetBlock<ErrorItemMessage> errorHandlingBlock)
+        {
+            SourceApiClient = sourceApiClient;
+            TargetApiClient = targetApiClient;
+            Options = options;
+            AuthorizationFailureHandling = authorizationFailureHandling;
+            ErrorHandlingBlock = errorHandlingBlock;
+        }
+
+        public EdFiApiClient SourceApiClient { get; set; }
+        public EdFiApiClient TargetApiClient { get; set; }
+        public Options Options { get; set; }
+        public AuthorizationFailureHandling[] AuthorizationFailureHandling { get; set; }
+        public ITargetBlock<ErrorItemMessage> ErrorHandlingBlock { get; set; }
+    }
+}

--- a/EdFi.Tools.ApiPublisher.Core/Processing/Blocks/DeleteResource.cs
+++ b/EdFi.Tools.ApiPublisher.Core/Processing/Blocks/DeleteResource.cs
@@ -22,13 +22,14 @@ namespace EdFi.Tools.ApiPublisher.Core.Processing.Blocks
         private static readonly ILog _logger = LogManager.GetLogger(typeof(DeleteResource));
         
         public static ValueTuple<ITargetBlock<GetItemForDeletionMessage>, ISourceBlock<ErrorItemMessage>> CreateBlocks(
-            EdFiApiClient targetApiClient, Options options,
-            ITargetBlock<ErrorItemMessage> errorHandlingBlock)
+            CreateBlocksRequest createBlocksRequest)
         {
-            var getItemForDeletionBlock =
-                CreateGetItemForDeletionBlock(targetApiClient, options, errorHandlingBlock);
+            var getItemForDeletionBlock = CreateGetItemForDeletionBlock(
+                createBlocksRequest.TargetApiClient,
+                createBlocksRequest.Options,
+                createBlocksRequest.ErrorHandlingBlock);
 
-            var deleteResourceBlock = CreateDeleteResourceBlock(targetApiClient, options);
+            var deleteResourceBlock = CreateDeleteResourceBlock(createBlocksRequest.TargetApiClient, createBlocksRequest.Options);
 
             getItemForDeletionBlock.LinkTo(deleteResourceBlock, new DataflowLinkOptions {PropagateCompletion = true});
             

--- a/EdFi.Tools.ApiPublisher.Core/Processing/Blocks/PostResource.cs
+++ b/EdFi.Tools.ApiPublisher.Core/Processing/Blocks/PostResource.cs
@@ -406,7 +406,7 @@ namespace EdFi.Tools.ApiPublisher.Core.Processing.Blocks
 
                                                 return targetEdFiApiClient.HttpClient.PostAsync(
                                                     $"{targetEdFiApiClient.DataManagementApiSegment}{missingDependencyResourcePath}",
-                                                    new StringContent(msg.Item.ToString(), Encoding.UTF8, "application/json"),
+                                                    new StringContent(missingItem.ToString(Formatting.None), Encoding.UTF8, "application/json"),
                                                     ct);
                                             },
                                             new Context(),

--- a/EdFi.Tools.ApiPublisher.Core/Processing/Blocks/PostResource.cs
+++ b/EdFi.Tools.ApiPublisher.Core/Processing/Blocks/PostResource.cs
@@ -414,8 +414,10 @@ namespace EdFi.Tools.ApiPublisher.Core.Processing.Blocks
 
                                     if (!missingItemPostResponse.IsSuccessStatusCode)
                                     {
+                                        string responseContent = await getByIdResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+
                                         _logger.Error(
-                                            $"{msg.ResourceUrl}: POST of missing '{referencedResourceName}' reference to the target returned status '{missingItemPostResponse.StatusCode}'.");
+                                            $"{msg.ResourceUrl}: POST of missing '{referencedResourceName}' reference to the target returned status '{missingItemPostResponse.StatusCode}': {responseContent}.");
                                     }
                                     else
                                     {

--- a/EdFi.Tools.ApiPublisher.Core/Processing/Blocks/PostResource.cs
+++ b/EdFi.Tools.ApiPublisher.Core/Processing/Blocks/PostResource.cs
@@ -1,14 +1,15 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
-using EdFi.Tools.ApiPublisher.Core.ApiClientManagement;
 using Newtonsoft.Json.Linq;
-using EdFi.Tools.ApiPublisher.Core.Configuration;
 using EdFi.Tools.ApiPublisher.Core.Extensions;
 using EdFi.Tools.ApiPublisher.Core.Processing.Messages;
 using log4net;
@@ -20,14 +21,30 @@ namespace EdFi.Tools.ApiPublisher.Core.Processing.Blocks
     public static class PostResource
     {
         private static readonly ILog _logger = LogManager.GetLogger(typeof(PostResource));
-        
-        public static ValueTuple<ITargetBlock<PostItemMessage>, ISourceBlock<ErrorItemMessage>> CreateBlocks(
-            EdFiApiClient targetApiClient,
-            Options options,
-            ITargetBlock<ErrorItemMessage> errorHandlingBlock)
+
+        public static ValueTuple<ITargetBlock<PostItemMessage>, ISourceBlock<ErrorItemMessage>> CreateBlocks(CreateBlocksRequest createBlocksRequest)
         {
-            var ignoredResourceByUrl = new ConcurrentDictionary<string, bool>();
+            var options = createBlocksRequest.Options;
+            var targetEdFiApiClient = createBlocksRequest.TargetApiClient;
+            var sourceEdFiApiClient = createBlocksRequest.SourceApiClient;
             
+            var ignoredResourceByUrl = new ConcurrentDictionary<string, bool>();
+
+            var missingDependencyByResourcePath = new Dictionary<string, string>();
+
+            var items = createBlocksRequest.AuthorizationFailureHandling.SelectMany(
+                h => h.UpdatePrerequisitePaths.Select(
+                    prereq => new
+                    {
+                        ResourcePath = prereq,
+                        DependencyResourcePath = h.Path
+                    }));
+
+            foreach (var item in items)
+            {
+                missingDependencyByResourcePath.Add(item.ResourcePath, item.DependencyResourcePath);
+            }
+
             var postResourceBlock = new TransformManyBlock<PostItemMessage, ErrorItemMessage>(
                 async msg =>
             {
@@ -67,15 +84,16 @@ namespace EdFi.Tools.ApiPublisher.Core.Processing.Blocks
 
                     var apiResponse = await Policy
                         .Handle<Exception>()
-                        .OrResult<HttpResponseMessage>(r => 
+                        .OrResult<HttpResponseMessage>(r =>  
                             // Descriptor Conflicts are not to be retried
                             (r.StatusCode == HttpStatusCode.Conflict && !msg.ResourceUrl.EndsWith("Descriptors", StringComparison.OrdinalIgnoreCase)) 
-                            || r.StatusCode.IsPotentiallyTransientFailure())
+                            || r.StatusCode.IsPotentiallyTransientFailure()
+                            || IsBadRequestForUnresolvedReferenceOfPrimaryRelationship(r, msg))
                         .WaitAndRetryAsync(delay, async (result, ts, retryAttempt, ctx) =>
                         {
                             if (result.Exception != null)
                             {
-                                _logger.Error($"{msg.ResourceUrl} (source id: {id}): POST attempt #{attempts} failed with an exception. . Retrying... (retry #{retryAttempt} of {options.MaxRetryAttempts} with {ts.TotalSeconds:N1}s delay):{Environment.NewLine}{result.Exception}");
+                                _logger.Error($"{msg.ResourceUrl} (source id: {id}): POST attempt #{attempts} failed with an exception. Retrying... (retry #{retryAttempt} of {options.MaxRetryAttempts} with {ts.TotalSeconds:N1}s delay):{Environment.NewLine}{result.Exception}");
                             }
                             else
                             {
@@ -84,7 +102,7 @@ namespace EdFi.Tools.ApiPublisher.Core.Processing.Blocks
                                 _logger.Warn($"{msg.ResourceUrl} (source id: {id}): POST attempt #{attempts} failed with status '{result.Result.StatusCode}'. Retrying... (retry #{retryAttempt} of {options.MaxRetryAttempts} with {ts.TotalSeconds:N1}s delay):{Environment.NewLine}{responseContent}");
                             }
                         })
-                        .ExecuteAsync((ctx, ct) =>
+                        .ExecuteAsync(async (ctx, ct) =>
                         {
                             attempts++;
 
@@ -100,11 +118,14 @@ namespace EdFi.Tools.ApiPublisher.Core.Processing.Blocks
                                 }
                             }
 
-                            return targetApiClient.HttpClient.PostAsync(
-                                $"{targetApiClient.DataManagementApiSegment}{msg.ResourceUrl}",
+                            var response = await targetEdFiApiClient.HttpClient.PostAsync(
+                                $"{targetEdFiApiClient.DataManagementApiSegment}{msg.ResourceUrl}",
                                 new StringContent(msg.Item.ToString(), Encoding.UTF8, "application/json"),
                                 ct);
-                            
+
+                            await HandleMissingDependencyAsync(response, msg);
+
+                            return response;
                         }, new Context(), CancellationToken.None);
 
                     // Failure
@@ -153,7 +174,7 @@ namespace EdFi.Tools.ApiPublisher.Core.Processing.Blocks
                         // If the failure is Forbidden, and we should treat it as a warning
                         if (apiResponse.StatusCode == HttpStatusCode.Forbidden
                             && msg.PostAuthorizationFailureRetry == null
-                            && targetApiClient.ConnectionDetails?.TreatForbiddenPostAsWarning == true)
+                            && targetEdFiApiClient.ConnectionDetails?.TreatForbiddenPostAsWarning == true)
                         {
                             // Warn and ignore all future data for this resource
                             _logger.Warn($"{msg.ResourceUrl} (source id: {id}): Authorization failed on POST of resource with no authorization failure handling defined. Remaining resource items will be ignored. Response status: {apiResponse.StatusCode}{Environment.NewLine}{responseContent}");
@@ -211,6 +232,201 @@ namespace EdFi.Tools.ApiPublisher.Core.Processing.Blocks
             });
             
             return (postResourceBlock, postResourceBlock);
+
+            async Task<string> GetResponseMessageTextAsync(HttpResponseMessage response)
+            {
+                try
+                {
+                    var responseMessageToken = JObject.Parse(await response.Content.ReadAsStringAsync());
+
+                    // If the failure message is related to a missing reference ("reference cannot be resolve")
+                    return responseMessageToken["message"]?.Value<string>();
+                }
+                catch (Exception)
+                {
+                    // Unable to parse response, unable to automatically recover
+                    return null;
+                }
+            }
+
+            string GetResponseMessageText(HttpResponseMessage response)
+            {
+                try
+                {
+                    string content = response.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+                    var responseMessageToken = JObject.Parse(content);
+
+                    // If the failure message is related to a missing reference ("reference cannot be resolve")
+                    return responseMessageToken["message"]?.Value<string>();
+                }
+                catch (Exception)
+                {
+                    // Unable to parse response, unable to automatically recover
+                    return null;
+                }
+            }
+
+            bool IsBadRequestForUnresolvedReferenceOfPrimaryRelationship(HttpResponseMessage postItemResponse, PostItemMessage msg)
+            {
+                // If response is a Bad Request, check for need to explicitly fetch dependencies
+                if (postItemResponse.StatusCode == HttpStatusCode.BadRequest)
+                {
+                    // If resource is a "primary relationship" configured in authorization failure handling
+                    if (missingDependencyByResourcePath.TryGetValue(msg.ResourceUrl, out string missingDependencyResourcePath))
+                    {
+                        string responseMessageText = GetResponseMessageText(postItemResponse);
+
+                        if (responseMessageText?.Contains("reference could not be resolved.") == true)
+                        {
+                            return true;
+                        }
+                    }
+                }
+
+                return false;
+            }
+            
+            async Task HandleMissingDependencyAsync(HttpResponseMessage postItemResponse, PostItemMessage msg)
+            {
+                // If response is a Bad Request, check for need to explicitly fetch dependencies
+                if (postItemResponse.StatusCode == HttpStatusCode.BadRequest)
+                {
+                    // If resource is a "primary relationship" configured in authorization failure handling
+                    if (missingDependencyByResourcePath.TryGetValue(msg.ResourceUrl, out string missingDependencyResourcePath))
+                    {
+                        string responseMessageText = await GetResponseMessageTextAsync(postItemResponse);
+
+                        if (responseMessageText?.Contains("reference could not be resolved.") == true)
+                        {
+                            // Infer reference name from message. This is a bit fragile, but no other choice here.
+                            var referenceNameMatch = Regex.Match(
+                                responseMessageText,
+                                @"(?<ReferencedResourceName>\w+) reference could not be resolved.");
+
+                            if (referenceNameMatch.Success)
+                            {
+                                //----------------------------------------------------------------------------------------------
+                                string referencedResourceName = referenceNameMatch.Groups["ReferencedResourceName"].Value;
+                                string referenceName = referencedResourceName.ToCamelCase() + "Reference";
+
+                                // Get the missing reference's source URL
+                                string dependencyItemUrl = msg.Item.SelectToken($"{referenceName}.link.href")?.Value<string>();
+
+                                if (_logger.IsDebugEnabled)
+                                {
+                                    _logger.Debug(
+                                        $"{msg.ResourceUrl}: Attempting to retrieve missing '{referencedResourceName}' reference based on 'authorizationFailureHandling' metadata in apiPublisherSettings.json.");
+                                }
+
+                                var getByIdDelay = Backoff.ExponentialBackoff(
+                                    TimeSpan.FromMilliseconds(options.RetryStartingDelayMilliseconds),
+                                    options.MaxRetryAttempts);
+
+                                int getByIdAttempts = 0;
+
+                                var getByIdResponse = await Policy
+                                    .HandleResult<HttpResponseMessage>(r => r.StatusCode.IsPotentiallyTransientFailure())
+                                    .WaitAndRetryAsync(
+                                        getByIdDelay,
+                                        (result, ts, retryAttempt, ctx) =>
+                                        {
+                                            _logger.Warn(
+                                                $"{msg.ResourceUrl}: Retrying GET for missing '{referencedResourceName}' reference from source failed with status '{result.Result.StatusCode}'. Retrying... (retry #{retryAttempt} of {options.MaxRetryAttempts} with {ts.TotalSeconds:N1}s delay)");
+                                        })
+                                    .ExecuteAsync(
+                                        (ctx, ct) =>
+                                        {
+                                            getByIdAttempts++;
+
+                                            if (getByIdAttempts > 1)
+                                            {
+                                                if (_logger.IsDebugEnabled)
+                                                {
+                                                    _logger.Debug(
+                                                        $"{msg.ResourceUrl}: GET for missing '{referencedResourceName}' reference from source attempt #{getByIdAttempts}.");
+                                                }
+                                            }
+
+                                            return sourceEdFiApiClient.HttpClient.GetAsync(
+                                                $"{sourceEdFiApiClient.DataManagementApiSegment}{dependencyItemUrl}",
+                                                ct);
+                                        },
+                                        new Context(),
+                                        CancellationToken.None);
+
+                                // Detect null content and provide a better error message (which happens only during unit testing if mocked requests aren't properly defined)
+                                if (getByIdResponse.Content == null)
+                                {
+                                    throw new NullReferenceException(
+                                        $"Content of response for '{sourceEdFiApiClient.HttpClient.BaseAddress}{sourceEdFiApiClient.DataManagementApiSegment}{dependencyItemUrl}' was null.");
+                                }
+
+                                // Did we successfully retrieve the missing dependency?
+                                if (getByIdResponse.StatusCode == HttpStatusCode.OK)
+                                {
+                                    string missingItemJson = await getByIdResponse.Content.ReadAsStringAsync();
+                                    var missingItem = JObject.Parse(missingItemJson);
+
+                                    // Clean up the JObject for POSTing against the target
+                                    // Remove attributes not usable between API instances
+                                    missingItem.Remove("id");
+                                    missingItem.Remove("_etag");
+
+                                    var missingItemDelay = Backoff.ExponentialBackoff(
+                                        TimeSpan.FromMilliseconds(options.RetryStartingDelayMilliseconds),
+                                        options.MaxRetryAttempts);
+
+                                    if (_logger.IsDebugEnabled)
+                                    {
+                                        _logger.Debug(
+                                            $"{msg.ResourceUrl}: Attempting to POST missing '{referencedResourceName}' reference to the target.");
+                                    }
+
+                                    // Post the resource to target now
+                                    var missingItemPostResponse = await Policy
+                                        .HandleResult<HttpResponseMessage>(r => r.StatusCode.IsPotentiallyTransientFailure())
+                                        .WaitAndRetryAsync(
+                                            missingItemDelay,
+                                            (result, ts, retryAttempt, ctx) =>
+                                            {
+                                                _logger.Warn(
+                                                    $"{msg.ResourceUrl}: Retrying POST for missing '{referencedResourceName}' reference against target failed with status '{result.Result.StatusCode}'. Retrying... (retry #{retryAttempt} of {options.MaxRetryAttempts} with {ts.TotalSeconds:N1}s delay)");
+                                            })
+                                        .ExecuteAsync(
+                                            (ctx, ct) =>
+                                            {
+                                                getByIdAttempts++;
+
+                                                if (getByIdAttempts > 1)
+                                                {
+                                                    if (_logger.IsDebugEnabled)
+                                                    {
+                                                        _logger.Debug(
+                                                            $"{msg.ResourceUrl}: GET for missing '{referencedResourceName}' reference from source attempt #{getByIdAttempts}.");
+                                                    }
+                                                }
+
+                                                return targetEdFiApiClient.HttpClient.PostAsync(
+                                                    $"{targetEdFiApiClient.DataManagementApiSegment}{missingDependencyResourcePath}",
+                                                    new StringContent(msg.Item.ToString(), Encoding.UTF8, "application/json"),
+                                                    ct);
+                                            },
+                                            new Context(),
+                                            CancellationToken.None);
+
+                                    if (_logger.IsDebugEnabled)
+                                    {
+                                        _logger.Debug(
+                                            $"{msg.ResourceUrl}: POST of missing '{referencedResourceName}' reference to the target returned status '{missingItemPostResponse.StatusCode}'.");
+                                    }
+                                }
+
+                                //----------------------------------------------------------------------------------------------
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         public static PostItemMessage CreateItemActionMessage(StreamResourcePageMessage<PostItemMessage> msg, JObject j)

--- a/EdFi.Tools.ApiPublisher.Core/Processing/Blocks/StreamResourcePages.cs
+++ b/EdFi.Tools.ApiPublisher.Core/Processing/Blocks/StreamResourcePages.cs
@@ -101,7 +101,7 @@ namespace EdFi.Tools.ApiPublisher.Core.Processing.Blocks
                             return message.EdFiApiClient.HttpClient.GetAsync($"{message.EdFiApiClient.DataManagementApiSegment}{message.ResourceUrl}?offset={offset}&limit={limit}{changeWindowParms}", ct);
                         }, new Context(), CancellationToken.None);
                     
-                    // Detect null content and provide a better error message (which happens during unit testing if mocked requests aren't properly defined)
+                    // Detect null content and provide a better error message (which happens only during unit testing if mocked requests aren't properly defined)
                     if (apiResponse.Content == null)
                     {
                         throw new NullReferenceException($"Content of response for '{message.EdFiApiClient.HttpClient.BaseAddress}{message.EdFiApiClient.DataManagementApiSegment}{message.ResourceUrl}?offset={offset}&limit={limit}{changeWindowParms}' was null.");

--- a/EdFi.Tools.ApiPublisher.Tests/Helpers/TestHelpers.cs
+++ b/EdFi.Tools.ApiPublisher.Tests/Helpers/TestHelpers.cs
@@ -32,13 +32,25 @@ namespace EdFi.Tools.ApiPublisher.Tests.Helpers
 
         public static Faker<FakeKey> GetKeyValueFaker()
         {
+            var linkValueFaker = GetLinkValueFaker();
+            
             // Initialize a generator for the fake natural key class
             var keyValueFaker = new Faker<FakeKey>().StrictMode(true)
                 .RuleFor(o => o.Name, f => f.Name.FirstName())
                 .RuleFor(o => o.RetirementAge, f => f.Random.Int(50, 75))
-                .RuleFor(o => o.BirthDate, f => f.Date.Between(DateTime.Today.AddYears(-75), DateTime.Today.AddYears(5)).Date);
+                .RuleFor(o => o.BirthDate, f => f.Date.Between(DateTime.Today.AddYears(-75), DateTime.Today.AddYears(5)).Date)
+                .RuleFor(o => o.Link, f => linkValueFaker.Generate());
 
             return keyValueFaker;
+        }
+
+        public static Faker<Link> GetLinkValueFaker(string href = null, string rel = "Some")
+        {
+            var linkFaker = new Faker<Link>().StrictMode(true)
+                .RuleFor(o => o.Rel, () => rel)
+                .RuleFor(o => o.Href, f => href ?? $"/ed-fi/somethings/{Guid.NewGuid():n}");
+
+            return linkFaker;
         }
 
         public static Options GetOptions()

--- a/EdFi.Tools.ApiPublisher.Tests/Helpers/TestHelpers.cs
+++ b/EdFi.Tools.ApiPublisher.Tests/Helpers/TestHelpers.cs
@@ -177,7 +177,7 @@ namespace EdFi.Tools.ApiPublisher.Tests.Helpers
             var ms = new MemoryStream();
             var sw = new StreamWriter(ms);
 
-            const string logLevel = "INFO";
+            // const string logLevel = "INFO";
             
             await sw.WriteLineAsync(
                 $@"

--- a/EdFi.Tools.ApiPublisher.Tests/MockRequests.cs
+++ b/EdFi.Tools.ApiPublisher.Tests/MockRequests.cs
@@ -228,6 +228,23 @@ namespace EdFi.Tools.ApiPublisher.Tests
 
             return fakeRequestHandler;
         }
+        
+        public static IFakeHttpRequestHandler Dependencies(this IFakeHttpRequestHandler fakeRequestHandler, string resourcePath)
+        {
+            A.CallTo(
+                    () => fakeRequestHandler.Get(
+                        $"{fakeRequestHandler.BaseUrl}/metadata/{fakeRequestHandler.DataManagementUrlSegment}/dependencies",
+                        A<HttpRequestMessage>.Ignored))
+                .Returns(FakeResponse.OK($@"<?xml version=""1.0"" encoding=""utf-8""?>
+<graphml xmlns=""http://graphml.graphdrawing.org/xmlns"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xsi:schemaLocation=""http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd"">
+  <graph id=""EdFi Dependencies"" edgedefault=""directed"">
+    <node id=""{resourcePath}""/>
+  </graph>
+</graphml>
+"));
+
+            return fakeRequestHandler;
+        }
 
         public static IFakeHttpRequestHandler ApiVersionMetadata(
             this IFakeHttpRequestHandler fakeRequestHandler,

--- a/EdFi.Tools.ApiPublisher.Tests/Models/FakeKey.cs
+++ b/EdFi.Tools.ApiPublisher.Tests/Models/FakeKey.cs
@@ -13,5 +13,17 @@ namespace EdFi.Tools.ApiPublisher.Tests.Models
         
         [JsonProperty("retirementAge")]
         public int RetirementAge { get; set; }
+
+        [JsonProperty("link")]
+        public Link Link { get; set; }
+    }
+
+    public class Link
+    {
+        [JsonProperty("rel")]
+        public string Rel { get; set; }
+        
+        [JsonProperty("href")]
+        public string Href { get; set; }
     }
 }

--- a/EdFi.Tools.ApiPublisher.Tests/Processing/UnresolvedDependencyOnPrimaryRelationshipTests.cs
+++ b/EdFi.Tools.ApiPublisher.Tests/Processing/UnresolvedDependencyOnPrimaryRelationshipTests.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using EdFi.Tools.ApiPublisher.Core.ApiClientManagement;
+using EdFi.Tools.ApiPublisher.Core.Configuration;
+using EdFi.Tools.ApiPublisher.Core.Dependencies;
+using EdFi.Tools.ApiPublisher.Core.Processing;
+using EdFi.Tools.ApiPublisher.Tests.Helpers;
+using FakeItEasy;
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace EdFi.Tools.ApiPublisher.Tests.Processing
+{
+    [TestFixture]
+    public class UnresolvedDependencyOnPrimaryRelationshipTests
+    {
+        [TestFixture]
+        public class When_publishing_a_primary_relationship_resource_with_a_missing_reference : TestFixtureAsyncBase
+        {
+            private ChangeProcessor _changeProcessor;
+            private ChangeProcessorConfiguration _changeProcessorConfiguration;
+            private IFakeHttpRequestHandler _fakeTargetRequestHandler;
+            private IFakeHttpRequestHandler _fakeSourceRequestHandler;
+            private string _suppliedSourceLinkHref;
+
+            public class MissingPerson
+            {
+                [JsonProperty("id")]
+                public string Id { get; set; }
+                
+                [JsonProperty("firstName")]
+                public string FirstName { get; set; }
+                
+                [JsonProperty("lastSurname")]
+                public string LastSurname { get; set; }
+                
+                [JsonProperty("_etag")]
+                public string ETag { get; set; }
+            }
+
+            const string TestResourcePath = "/ed-fi/studentSchoolAssociations";
+
+            protected override async Task ArrangeAsync()
+            {
+                // -----------------------------------------------------------------
+                //                      Source Requests
+                // -----------------------------------------------------------------
+                var sourceResourceFaker = TestHelpers.GetGenericResourceFaker();
+            
+                var suppliedSourceResources = sourceResourceFaker.Generate(1);
+
+                // Prepare the fake source API endpoint
+                _fakeSourceRequestHandler = TestHelpers.GetFakeBaselineSourceApiRequestHandler()
+                    // Test-specific mocks
+                    .AvailableChangeVersions(1100)
+                    .ResourceCount(responseTotalCountHeader: 1)
+                    .GetResourceData($"{EdFiApiConstants.DataManagementApiSegment}{TestResourcePath}", suppliedSourceResources);
+                // -----------------------------------------------------------------
+
+                // Get the path of the missing item from the 'link' in the reference object
+                _suppliedSourceLinkHref = suppliedSourceResources.Single().SomeReference.Link.Href;
+
+                // Fake the expected response item  
+                var suppliedMissingPerson = new MissingPerson
+                {
+                    Id = Guid.NewGuid().ToString("n"),
+                    FirstName = "Bob",
+                    LastSurname = "Jones",
+                    ETag = "etagvalue"
+                };
+
+                _fakeSourceRequestHandler.GetResourceDataItem(
+                    $"{EdFiApiConstants.DataManagementApiSegment}{_suppliedSourceLinkHref}",
+                    suppliedMissingPerson);
+
+                // -----------------------------------------------------------------
+                //                      Target Requests
+                // -----------------------------------------------------------------
+               
+                _fakeTargetRequestHandler = TestHelpers.GetFakeBaselineTargetApiRequestHandler();
+                _fakeTargetRequestHandler.PostResource( $"{EdFiApiConstants.DataManagementApiSegment}{TestResourcePath}", 
+                    (HttpStatusCode.BadRequest, JObject.Parse("{\r\n  \"message\": \"Validation of 'StudentSchoolAssociation' failed.\\r\\n\\tSome reference could not be resolved.\\n\"\r\n}")), 
+                    (HttpStatusCode.OK, null));
+            
+                // -----------------------------------------------------------------
+
+                var sourceApiConnectionDetails = TestHelpers.GetSourceApiConnectionDetails(
+                    resources: new []{ TestResourcePath });
+            
+                var targetApiConnectionDetails = TestHelpers.GetTargetApiConnectionDetails();
+
+                EdFiApiClient SourceApiClientFactory() =>
+                    new EdFiApiClient(
+                        "TestSource",
+                        sourceApiConnectionDetails,
+                        bearerTokenRefreshMinutes: 27,
+                        ignoreSslErrors: true,
+                        httpClientHandler: new HttpClientHandlerFakeBridge(_fakeSourceRequestHandler));
+
+                EdFiApiClient TargetApiClientFactory() =>
+                    new EdFiApiClient(
+                        "TestTarget",
+                        targetApiConnectionDetails,
+                        bearerTokenRefreshMinutes: 27,
+                        ignoreSslErrors: true,
+                        httpClientHandler: new HttpClientHandlerFakeBridge(_fakeTargetRequestHandler));
+
+                var authorizationFailureHandling = TestHelpers.Configuration.GetAuthorizationFailureHandling();
+
+                // Only include descriptors if our test subject resource is a descriptor (trying to avoid any dependencies to keep things simpler)
+                var options = TestHelpers.GetOptions();
+                options.IncludeDescriptors = false;
+                
+                var configurationStoreSection = null as IConfigurationSection; //new ConfigurationSection()
+
+                _changeProcessorConfiguration = new ChangeProcessorConfiguration(
+                    authorizationFailureHandling,
+                    Array.Empty<string>(),
+                    sourceApiConnectionDetails,
+                    targetApiConnectionDetails,
+                    SourceApiClientFactory,
+                    TargetApiClientFactory,
+                    options,
+                    configurationStoreSection);
+
+                // Initialize logging
+                var loggerRepository = await TestHelpers.InitializeLogging();
+
+                // Create dependencies
+                var resourceDependencyProvider = new EdFiV3ApiResourceDependencyProvider();
+                var changeVersionProcessedWriter = A.Fake<IChangeVersionProcessedWriter>();
+                var errorPublisher = A.Fake<IErrorPublisher>();
+
+                _changeProcessor = new ChangeProcessor(resourceDependencyProvider, changeVersionProcessedWriter, errorPublisher);
+            }
+
+            protected override async Task ActAsync()
+            {
+                await _changeProcessor.ProcessChangesAsync(_changeProcessorConfiguration, CancellationToken.None);
+            }
+
+            [Test]
+            public void Should_attempt_to_post_the_resource_with_the_reference_that_cannot_be_resolved_to_the_target_API_twice()
+            {
+                A.CallTo(
+                        () => _fakeTargetRequestHandler.Post(
+                            $"{MockRequests.TargetApiBaseUrl}{MockRequests.DataManagementPath}{TestResourcePath}",
+                            A<HttpRequestMessage>.Ignored))
+                    .MustHaveHappened(2, Times.Exactly); // Once original attempt, then a second time once the reference has been resolved
+            }
+
+            [Test]
+            public void Should_attempt_to_get_the_item_for_the_unresolved_reference_from_the_source_API()
+            {
+                A.CallTo(
+                        () => _fakeSourceRequestHandler.Get(
+                            $"{MockRequests.SourceApiBaseUrl}{MockRequests.DataManagementPath}{_suppliedSourceLinkHref}",
+                            A<HttpRequestMessage>.Ignored))
+                    .MustHaveHappened();
+            }
+            
+            [Test]
+            public void Should_attempt_to_post_the_item_for_the_unresolved_reference_to_the_target_API()
+            {
+                A.CallTo(
+                        () => _fakeTargetRequestHandler.Post(
+                            $"{MockRequests.TargetApiBaseUrl}{MockRequests.DataManagementPath}/ed-fi/students", // This is from the authorizationFailureHandling
+                            A<HttpRequestMessage>.Ignored))
+                    .MustHaveHappened();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Detect unresolved references on the primary relationships used for authorization and retrieve the missing item from the source. 

The scenario where this occurred was data was published for a particular school, an existing student was subsequently enrolled in that school (but the student's record wasn't updated), and data was then publishing a second time. Because there was no change to the Student record in the source ODS, it wasn't published. The API Publisher will now detect this scenario and reactively retrieve the missing Student (or Staff or Parent, as the case may be), POST it to the target API and retry POSTing the association record that caused the initial failure.